### PR TITLE
general improvements

### DIFF
--- a/wrath/ABCategoryData_wrath.lua
+++ b/wrath/ABCategoryData_wrath.lua
@@ -257,6 +257,8 @@ function ABGCode.InitializeCategories()
 		"*", ABGCode.GetSpellNameByName("Disenchant"),
 		"*", ABGCode.GetSpellNameByName("Enchanting"),
 		"*", ABGCode.GetSpellNameByName("Engineering"),
+		"*", ABGCode.GetSpellNameByName("Inscription"),
+		"*", ABGCode.GetSpellNameByName("Milling"),
 		"*", ABGCode.GetSpellNameByName("Jewelcrafting"),
 		"*", ABGCode.GetSpellNameByName("Prospecting"),
 		"*", ABGCode.GetSpellNameByName("First Aid"),

--- a/wrath/ABCategoryData_wrath.lua
+++ b/wrath/ABCategoryData_wrath.lua
@@ -16,13 +16,9 @@ function ABGCode.InitializeCategories()
 	AutoBarCategoryList["Muffin.Poison.Lethal"] = ItemsCategory:new("Muffin.Poison.Lethal", "INV_Misc_Food_95_Grainbread", "Muffin.Poison.Lethal")
 	AutoBarCategoryList["Muffin.Poison.Nonlethal"] = ItemsCategory:new("Muffin.Poison.Nonlethal", "INV_Misc_Food_95_Grainbread", "Muffin.Poison.Nonlethal")
 
-	AutoBarCategoryList["Spell.Warlock.Create Healthstone"] = SpellsCategory:new( "Spell.Warlock.Create Healthstone", spellIconList["Create Healthstone"],
+	AutoBarCategoryList["Spell.Warlock.Create Healthstone"] = SpellsCategory:new( "Spell.Warlock.Create Healthstone", spellIconList["Create Healthstone"], nil,
 	{
-		"WARLOCK", ABGCode.GetSpellNameByName("Create Healthstone (Minor)"),
-		"WARLOCK", ABGCode.GetSpellNameByName("Create Healthstone (Lesser)"),
-		"WARLOCK", ABGCode.GetSpellNameByName("Create Healthstone"),
-		"WARLOCK", ABGCode.GetSpellNameByName("Create Healthstone (Greater)"),
-		"WARLOCK", ABGCode.GetSpellNameByName("Create Healthstone (Major)"),
+		"WARLOCK", ABGCode.GetSpellNameByName("Create Healthstone"), ABGCode.GetSpellNameByName("Ritual of Souls"),
 	})
 
 	AutoBarCategoryList["Spell.Warlock.Create Soulstone"] = SpellsCategory:new( "Spell.Warlock.Create Soulstone", spellIconList["Create Soulstone"],

--- a/wrath/ABCategoryData_wrath.lua
+++ b/wrath/ABCategoryData_wrath.lua
@@ -222,7 +222,6 @@ function ABGCode.InitializeCategories()
 
 	AutoBarCategoryList["Spell.Totem.Fire"] = SpellsCategory:new("Spell.Totem.Fire", spellIconList["Liquid Magma Totem"],
 	{
-		"SHAMAN", ABGCode.GetSpellNameByName("Fire Nova Totem"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Flametongue Totem"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Frost Resistance Totem"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Magma Totem"),
@@ -242,6 +241,7 @@ function ABGCode.InitializeCategories()
 
 	AutoBarCategoryList["Spell.Buff.Weapon"] = SpellsCategory:new("Spell.Buff.Weapon", spellIconList["Deadly Poison"],
 	{
+		"SHAMAN", ABGCode.GetSpellNameByName("Earthliving Weapon"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Flametongue Weapon"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Frostbrand Weapon"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Rockbiter Weapon"),

--- a/wrath/CachedSpellData_wrath.lua
+++ b/wrath/CachedSpellData_wrath.lua
@@ -313,6 +313,8 @@ ABGCS.CacheSpellData(2580, "Find Minerals");
 ABGCS.CacheSpellData(2383, "Find Herbs");
 ABGCS.CacheSpellData(25229, "Jewelcrafting");
 ABGCS.CacheSpellData(31252, "Prospecting");
+ABGCS.CacheSpellData(45357, "Inscription");
+ABGCS.CacheSpellData(51005, "Milling");
 
 
 local cache_timer_stop = debugprofilestop();

--- a/wrath/CachedSpellData_wrath.lua
+++ b/wrath/CachedSpellData_wrath.lua
@@ -182,6 +182,7 @@ ABGCS.CacheSpellData(36554, "Shadowstep");
 
 
 --#region Shaman
+ABGCS.CacheSpellData(51730, "Earthliving Weapon");
 ABGCS.CacheSpellData(8024, "Flametongue Weapon");
 ABGCS.CacheSpellData(8033, "Frostbrand Weapon");
 ABGCS.CacheSpellData(8017, "Rockbiter Weapon");
@@ -206,7 +207,6 @@ ABGCS.CacheSpellData(8075, "Strength of Earth Totem");
 ABGCS.CacheSpellData(8143, "Tremor Totem");
 
 --Fire totems
-ABGCS.CacheSpellData(1535, "Fire Nova Totem");
 ABGCS.CacheSpellData(16387, "Flametongue Totem");
 ABGCS.CacheSpellData(8181, "Frost Resistance Totem");
 ABGCS.CacheSpellData(8190, "Magma Totem");

--- a/wrath/CachedSpellData_wrath.lua
+++ b/wrath/CachedSpellData_wrath.lua
@@ -230,11 +230,17 @@ ABGCS.CacheSpellData(687, "Demon Skin");
 ABGCS.CacheSpellData(706, "Demon Armor");
 ABGCS.CacheSpellData(28176, "Fel Armor");
 
-ABGCS.CacheSpellData(6201, "Create Healthstone (Minor)");
-ABGCS.CacheSpellData(6202, "Create Healthstone (Lesser)");
-ABGCS.CacheSpellData(5699, "Create Healthstone");
-ABGCS.CacheSpellData(11729, "Create Healthstone (Greater)");
-ABGCS.CacheSpellData(11730, "Create Healthstone (Major)");
+ABGCS.CacheSpellData(6201, "Create Healthstone");
+-- ABGCS.CacheSpellData(6202, "Create Healthstone (Lesser)");
+-- ABGCS.CacheSpellData(5699, "Create Healthstone");
+-- ABGCS.CacheSpellData(11729, "Create Healthstone (Greater)");
+-- ABGCS.CacheSpellData(11730, "Create Healthstone (Major)");
+-- ABGCS.CacheSpellData(27230, "Create Healthstone (Master)");
+-- ABGCS.CacheSpellData(47871, "Create Healthstone (Demonic)");
+-- ABGCS.CacheSpellData(47878, "Create Healthstone (Fel)");
+
+ABGCS.CacheSpellData(29893, "Ritual of Souls");
+-- ABGCS.CacheSpellData(58887, "Ritual of Souls (Fel)");
 
 --ABGCS.CacheSpellData(00000, "XXX");
 
@@ -264,7 +270,6 @@ ABGCS.CacheSpellData(20756, "Create Soulstone (Greater)");
 ABGCS.CacheSpellData(20757, "Create Soulstone (Major)");
 
 ABGCS.CacheSpellData(698, "Ritual of Summoning");
-
 
 ABGCS.CacheSpellData(18220, "Dark Pact");
 ABGCS.CacheSpellData(5697, "Unending Breath");


### PR DESCRIPTION
inscription

warlock healthstone, ritual of souls on right click
also removed duplication of healthstone, you can only have 1 in the inventory, no matter the rank
we *could* remove the soulstone duplication, you can have multiple in the inventory
of different ranks but cooldown is shared, so clean it up later ?

shaman earth living and remove fire nova totem