### PR TITLE
general pass 2

### DIFF
--- a/AutoBarDB.lua
+++ b/AutoBarDB.lua
@@ -317,6 +317,7 @@ function AutoBar:InitializeDefaults()
 			{button_name = "AutoBarButtonTravel", },
 			{button_name = "AutoBarButtonAquatic", project_id = WOW_PROJECT_CLASSIC},
 			{button_name = "AutoBarButtonAquatic", project_id = WOW_PROJECT_BURNING_CRUSADE_CLASSIC},
+			{button_name = "AutoBarButtonAquatic", project_id = WOW_PROJECT_WRATH_CLASSIC},
 			{button_name = "AutoBarButtonStagForm", project_id = WOW_PROJECT_MAINLINE},
 			{button_name = "AutoBarButtonMoonkin", },
 			{button_name = "AutoBarButtonTreeForm", },
@@ -325,6 +326,7 @@ function AutoBar:InitializeDefaults()
 			{button_name = "AutoBarButtonClassBuff", },
 			{button_name = "AutoBarButtonStance", project_id = WOW_PROJECT_CLASSIC},
 			{button_name = "AutoBarButtonStance", project_id = WOW_PROJECT_BURNING_CRUSADE_CLASSIC},
+			{button_name = "AutoBarButtonStance", project_id = WOW_PROJECT_WRATH_CLASSIC},
 			{button_name = "AutoBarButtonShields", },
 			{button_name = "AutoBarButtonInterrupt", },
 			{button_name = "AutoBarButtonER", },
@@ -350,6 +352,8 @@ function AutoBar:InitializeDefaults()
 			{button_name = "AutoBarButtonTrack", project_id = WOW_PROJECT_CLASSIC},
 			{button_name = "AutoBarButtonSeal", project_id = WOW_PROJECT_BURNING_CRUSADE_CLASSIC},
 			{button_name = "AutoBarButtonTrack", project_id = WOW_PROJECT_BURNING_CRUSADE_CLASSIC},
+			{button_name = "AutoBarButtonSeal", project_id = WOW_PROJECT_WRATH_CLASSIC},
+			{button_name = "AutoBarButtonTrack", project_id = WOW_PROJECT_WRATH_CLASSIC},
 		},
 		PRIEST =
 		{
@@ -370,6 +374,7 @@ function AutoBar:InitializeDefaults()
 			{button_name = "AutoBarButtonER", },
 			{button_name = "AutoBarButtonTrap", project_id = WOW_PROJECT_CLASSIC},
 			{button_name = "AutoBarButtonTrap", project_id = WOW_PROJECT_BURNING_CRUSADE_CLASSIC},
+			{button_name = "AutoBarButtonTrap", project_id = WOW_PROJECT_WRATH_CLASSIC},
 		},
 		WARLOCK =
 		{
@@ -381,6 +386,7 @@ function AutoBar:InitializeDefaults()
 			{button_name = "AutoBarButtonDebuff", },
 			{button_name = "AutoBarButtonTrack", project_id = WOW_PROJECT_CLASSIC},
 			{button_name = "AutoBarButtonTrack", project_id = WOW_PROJECT_BURNING_CRUSADE_CLASSIC},
+			{button_name = "AutoBarButtonTrack", project_id = WOW_PROJECT_WRATH_CLASSIC},
 			{button_name = "AutoBarButtonClassPet", },
 		},
 		WARRIOR =

--- a/wrath/ABCategoryData_wrath.lua
+++ b/wrath/ABCategoryData_wrath.lua
@@ -30,34 +30,23 @@ function ABGCode.InitializeCategories()
 		"WARLOCK", ABGCode.GetSpellNameByName("Create Soulstone (Major)"),
 	})
 
-	AutoBarCategoryList["Spell.Mage.Create Manastone"] = SpellsCategory:new( "Spell.Mage.Create Manastone", spellIconList["Conjure Mana Jade"],
+	AutoBarCategoryList["Spell.Mage.Create Manastone"] = SpellsCategory:new( "Spell.Mage.Create Manastone", spellIconList["Conjure Mana Gem"],
 	{
-		"MAGE", ABGCode.GetSpellNameByName("Conjure Mana Jade"),
-		"MAGE", ABGCode.GetSpellNameByName("Conjure Mana Ruby"),
-		"MAGE", ABGCode.GetSpellNameByName("Conjure Mana Agate"),
-		"MAGE", ABGCode.GetSpellNameByName("Conjure Mana Citrine"),
-		"MAGE", ABGCode.GetSpellNameByName("Conjure Mana Emerald"),
+		"MAGE", ABGCode.GetSpellNameByName("Conjure Mana Gem"),
 	})
 
-
-	AutoBarCategoryList["Spell.Mage.Conjure Food"] = SpellsCategory:new( "Spell.Mage.Conjure Food", spellIconList["Conjure Refreshment"], {
-		"MAGE", ABGCode.GetSpellNameByName("Conjure Food"),
+	AutoBarCategoryList["Spell.Mage.Conjure Food"] = SpellsCategory:new( "Spell.Mage.Conjure Food", spellIconList["Conjure Food"], nil, {
+		"MAGE", ABGCode.GetSpellNameByName("Conjure Food"), ABGCode.GetSpellNameByName("Ritual of Refreshment")
 	})
 
-	AutoBarCategoryList["Spell.Mage.Conjure Water"] = SpellsCategory:new("Spell.Mage.Conjure Water", spellIconList["Conjure Refreshment"], {
-		"MAGE", ABGCode.GetSpellNameByName("Conjure Water"),
+	AutoBarCategoryList["Spell.Mage.Conjure Water"] = SpellsCategory:new("Spell.Mage.Conjure Water", spellIconList["Conjure Water"], nil, {
+		"MAGE", ABGCode.GetSpellNameByName("Conjure Water"), ABGCode.GetSpellNameByName("Ritual of Refreshment")
 	})
-
-	AutoBarCategoryList["Consumable.Food.Conjure"] = SpellsCategory:new("Consumable.Food.Conjure", spellIconList["Conjure Refreshment"], {
---			"MAGE", ABGCode.GetSpellNameByName("Conjure Refreshment"),
-			})
-
 
 	AutoBarCategoryList["Spell.Stealth"] = SpellsCategory:new("Spell.Stealth", spellIconList["Stealth"],
 	{
 		"DRUID", ABGCode.GetSpellNameByName("Prowl"),
 		"MAGE", ABGCode.GetSpellNameByName("Invisibility"),
-		"MAGE", ABGCode.GetSpellNameByName("Lesser Invisibility"),
 		"ROGUE", ABGCode.GetSpellNameByName("Stealth"),
 		"*", ABGCode.GetSpellNameByName("Shadowmeld"),
 	})
@@ -114,8 +103,6 @@ function ABGCode.InitializeCategories()
 
 	})
 
-
-
 	AutoBarCategoryList["Spell.Class.Pets2"] = SpellsCategory:new( "Spell.Class.Pets2", spellIconList["Call Pet 1"],
 	{
 		"HUNTER", ABGCode.GetSpellNameByName("Bestial Wrath"),
@@ -154,7 +141,6 @@ function ABGCode.InitializeCategories()
 		"WARLOCK", ABGCode.GetSpellNameByName("Ritual of Summoning"), ABGCode.GetSpellNameByName("Ritual of Summoning"),
 	
 	})
-
 
 	AutoBarCategoryList["Spell.Shields"] = SpellsCategory:new( "Spell.Shields", spellIconList["Ice Barrier"], nil,
 	{

--- a/wrath/ABCategoryData_wrath.lua
+++ b/wrath/ABCategoryData_wrath.lua
@@ -65,22 +65,24 @@ function ABGCode.InitializeCategories()
 	AutoBarCategoryList["Spell.Class.Buff"] = SpellsCategory:new( "Spell.Class.Buff", spellIconList["Barkskin"], nil,
 	{
 		"MAGE", ABGCode.GetSpellNameByName("Slow Fall"), ABGCode.GetSpellNameByName("Slow Fall"),
-		"MAGE", ABGCode.GetSpellNameByName("Arcane Intellect"), ABGCode.GetSpellNameByName("Arcane Brilliance"),
 		"MAGE", ABGCode.GetSpellNameByName("Amplify Magic"), ABGCode.GetSpellNameByName("Amplify Magic"),
 		"MAGE", ABGCode.GetSpellNameByName("Dampen Magic"), ABGCode.GetSpellNameByName("Dampen Magic"),
-		"DRUID", ABGCode.GetSpellNameByName("Mark of the Wild"), ABGCode.GetSpellNameByName("Gift of the Wild"),
+		"MAGE", ABGCode.GetSpellNameByName("Arcane Intellect"), ABGCode.GetSpellNameByName("Arcane Brilliance"),
 		"DRUID", ABGCode.GetSpellNameByName("Thorns"), ABGCode.GetSpellNameByName("Thorns"),
+		"DRUID", ABGCode.GetSpellNameByName("Mark of the Wild"), ABGCode.GetSpellNameByName("Gift of the Wild"),
 		"DEATHKNIGHT", ABGCode.GetSpellNameByName("Horn of Winter"), ABGCode.GetSpellNameByName("Horn of Winter"),
-		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Might"), ABGCode.GetSpellNameByName("Blessing of Might"),
-		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Protection"), ABGCode.GetSpellNameByName("Blessing of Protection"),
-		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Sacrifice"), ABGCode.GetSpellNameByName("Blessing of Sacrifice"),
-		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Salvation"), ABGCode.GetSpellNameByName("Blessing of Salvation"),
-		"PALADIN", ABGCode.GetSpellNameByName("Greater Blessing of Kings"), ABGCode.GetSpellNameByName("Greater Blessing of Kings"),
+		"PALADIN", ABGCode.GetSpellNameByName("Hand of Salvation"), ABGCode.GetSpellNameByName("Hand of Salvation"),
+		"PALADIN", ABGCode.GetSpellNameByName("Hand of Sacrifice"), ABGCode.GetSpellNameByName("Hand of Sacrifice"),
+		"PALADIN", ABGCode.GetSpellNameByName("Hand of Freedom"), ABGCode.GetSpellNameByName("Hand of Freedom"),
+		"PALADIN", ABGCode.GetSpellNameByName("Hand of Protection"), ABGCode.GetSpellNameByName("Hand of Protection"),
+		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Sanctuary"), ABGCode.GetSpellNameByName("Greater Blessing of Sanctuary"),
 		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Wisdom"), ABGCode.GetSpellNameByName("Greater Blessing of Wisdom"),
-		"PRIEST", ABGCode.GetSpellNameByName("Power Word: Fortitude"), ABGCode.GetSpellNameByName("Prayer of Fortitude"),
+		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Might"), ABGCode.GetSpellNameByName("Greater Blessing of Might"),
+		"PALADIN", ABGCode.GetSpellNameByName("Blessing of Kings"), ABGCode.GetSpellNameByName("Greater Blessing of Kings"),
+		"PRIEST", ABGCode.GetSpellNameByName("Fear Ward"), ABGCode.GetSpellNameByName("Fear Ward"),
 		"PRIEST", ABGCode.GetSpellNameByName("Inner Fire"), ABGCode.GetSpellNameByName("Inner Fire"),
 		"PRIEST", ABGCode.GetSpellNameByName("Shadow Protection"), ABGCode.GetSpellNameByName("Prayer of Shadow Protection"),
-		"PRIEST", ABGCode.GetSpellNameByName("Fear Ward"), ABGCode.GetSpellNameByName("Fear Ward"),
+		"PRIEST", ABGCode.GetSpellNameByName("Power Word: Fortitude"), ABGCode.GetSpellNameByName("Prayer of Fortitude"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Water Walking"), ABGCode.GetSpellNameByName("Water Walking"),
 		"WARLOCK", ABGCode.GetSpellNameByName("Unending Breath"), ABGCode.GetSpellNameByName("Unending Breath"),
 		"WARRIOR", ABGCode.GetSpellNameByName("Battle Shout"), ABGCode.GetSpellNameByName("Battle Shout"),
@@ -139,7 +141,7 @@ function ABGCode.InitializeCategories()
 		"MAGE", ABGCode.GetSpellNameByName("Teleport: Shattrath - Horde"), ABGCode.GetSpellNameByName("Portal: Shattrath - Horde"),
 		"SHAMAN", ABGCode.GetSpellNameByName("Astral Recall"), ABGCode.GetSpellNameByName("Astral Recall"),
 		"WARLOCK", ABGCode.GetSpellNameByName("Ritual of Summoning"), ABGCode.GetSpellNameByName("Ritual of Summoning"),
-	
+
 	})
 
 	AutoBarCategoryList["Spell.Shields"] = SpellsCategory:new( "Spell.Shields", spellIconList["Ice Barrier"], nil,
@@ -165,7 +167,7 @@ function ABGCode.InitializeCategories()
 
 	})
 
-	AutoBarCategoryList["Spell.Stance"] = SpellsCategory:new( "Spell.Stance", spellIconList["Defensive Stance"], 
+	AutoBarCategoryList["Spell.Stance"] = SpellsCategory:new( "Spell.Stance", spellIconList["Defensive Stance"],
 	{
 		"DEATHKNIGHT", ABGCode.GetSpellNameByName("Blood Presence"),
 		"DEATHKNIGHT", ABGCode.GetSpellNameByName("Frost Presence"),
@@ -192,12 +194,13 @@ function ABGCode.InitializeCategories()
 	})
 
 	AutoBarCategoryList["Spell.Seal"] = SpellsCategory:new( "Spell.Seal", spellIconList["Seal of the Crusader"], {
-		"PALADIN", ABGCode.GetSpellNameByName("Seal of Command"),
 		"PALADIN", ABGCode.GetSpellNameByName("Seal of Justice"),
 		"PALADIN", ABGCode.GetSpellNameByName("Seal of Light"),
-		"PALADIN", ABGCode.GetSpellNameByName("Seal of Righteousness"),
-		"PALADIN", ABGCode.GetSpellNameByName("Seal of the Martyr"),
 		"PALADIN", ABGCode.GetSpellNameByName("Seal of Wisdom"),
+		"PALADIN", ABGCode.GetSpellNameByName("Seal of Vengeance"),
+		"PALADIN", ABGCode.GetSpellNameByName("Seal of Corruption"),
+		"PALADIN", ABGCode.GetSpellNameByName("Seal of Righteousness"),
+		"PALADIN", ABGCode.GetSpellNameByName("Seal of Command"),
 	})
 
 	AutoBarCategoryList["Spell.Totem.Earth"] = SpellsCategory:new("Spell.Totem.Earth", spellIconList["Earthgrab Totem"],

--- a/wrath/CachedSpellData_wrath.lua
+++ b/wrath/CachedSpellData_wrath.lua
@@ -146,16 +146,23 @@ ABGCS.CacheSpellData(35715, "Teleport: Shattrath - Horde");
 --#region Paladin
 ABGCS.CacheSpellData(498, "Divine Protection");
 ABGCS.CacheSpellData(642, "Divine Shield");
-ABGCS.CacheSpellData(1044, "Blessing of Freedom");
-ABGCS.CacheSpellData(1022, "Blessing of Protection");
-ABGCS.CacheSpellData(6940, "Blessing of Sacrifice");
-ABGCS.CacheSpellData(1038, "Blessing of Salvation");
-ABGCS.CacheSpellData(25898, "Greater Blessing of Kings");
-ABGCS.CacheSpellData(19742, "Blessing of Wisdom");
-ABGCS.CacheSpellData(25894, "Greater Blessing of Wisdom");
-ABGCS.CacheSpellData(633, "Lay on Hands");
+-- ABGCS.CacheSpellData(64205, "Divine Sacrifice"); -- Prot, Not sure where to put it
 
 ABGCS.CacheSpellData(19740, "Blessing of Might");
+ABGCS.CacheSpellData(25782, "Greater Blessing of Might");
+ABGCS.CacheSpellData(19742, "Blessing of Wisdom");
+ABGCS.CacheSpellData(25894, "Greater Blessing of Wisdom");
+ABGCS.CacheSpellData(20217, "Blessing of Kings");
+ABGCS.CacheSpellData(25898, "Greater Blessing of Kings");
+ABGCS.CacheSpellData(20911, "Blessing of Sanctuary");
+ABGCS.CacheSpellData(25899, "Greater Blessing of Sanctuary");
+
+ABGCS.CacheSpellData(633, "Lay on Hands");
+
+ABGCS.CacheSpellData(1044, "Hand of Freedom");
+ABGCS.CacheSpellData(1022, "Hand of Protection");
+ABGCS.CacheSpellData(6940, "Hand of Sacrifice");
+ABGCS.CacheSpellData(1038, "Hand of Salvation");
 
 ABGCS.CacheSpellData(32223, "Crusader Aura");
 ABGCS.CacheSpellData(465, "Devotion Aura");
@@ -167,12 +174,13 @@ ABGCS.CacheSpellData(19876, "Shadow Resistance Aura");
 
 ABGCS.CacheSpellData(5502, "Sense Undead");
 
-ABGCS.CacheSpellData(20375, "Seal of Command");
+ABGCS.CacheSpellData(20375, "Seal of Command"); -- Ret
 ABGCS.CacheSpellData(20164, "Seal of Justice");
 ABGCS.CacheSpellData(20165, "Seal of Light");
 ABGCS.CacheSpellData(20154, "Seal of Righteousness");
-ABGCS.CacheSpellData(348700, "Seal of the Martyr");
 ABGCS.CacheSpellData(20166, "Seal of Wisdom");
+ABGCS.CacheSpellData(31801, "Seal of Vengeance"); -- Alliance
+ABGCS.CacheSpellData(53736, "Seal of Corruption"); -- Horde
 --#endregion
 
 --#region Priest

--- a/wrath/CachedSpellData_wrath.lua
+++ b/wrath/CachedSpellData_wrath.lua
@@ -109,17 +109,12 @@ ABGCS.CacheSpellData(604, "Dampen Magic");
 ABGCS.CacheSpellData(5504, "Conjure Water");
 ABGCS.CacheSpellData(587, "Conjure Food");
 
-ABGCS.CacheSpellData(759, "Conjure Mana Agate");
-ABGCS.CacheSpellData(10054, "Conjure Mana Ruby");
-ABGCS.CacheSpellData(3552, "Conjure Mana Jade");
-ABGCS.CacheSpellData(10053, "Conjure Mana Citrine");
-ABGCS.CacheSpellData(27101, "Conjure Mana Emerald");
+ABGCS.CacheSpellData(759, "Conjure Mana Gem");
+
+ABGCS.CacheSpellData(43987, "Ritual of Refreshment");
 
 ABGCS.CacheSpellData(31687, "Summon Water Elemental");
 
---ABGCS.CacheSpellData(42955, "Conjure Refreshment");
---ABGCS.CacheSpellData(43987, "Conjure Refreshment Table");
-ABGCS.CacheSpellData(7870, "Lesser Invisibility");
 ABGCS.CacheSpellData(66, "Invisibility");
 
 ABGCS.CacheSpellData(11418, "Portal: Undercity");


### PR DESCRIPTION
mage cleanup:
only Conjure Mana Gem now
ritual of refreshment on right click of conjure food/water
and lesser invisibility is a warlock pet spell => clean
conjure refreshment must be a retail thing => clean

general pass to enable some button types in wrath, analog to classic/tbc

and a paladin pass (blessing/hand)