### PR TITLE
Issue #134 - Remove special handling for Vanilla in RegisterForClicks

### DIFF
--- a/AutoBarClassic.toc
+++ b/AutoBarClassic.toc
@@ -1,7 +1,7 @@
 ## Interface: 11507
 ## Title: AutoBarClassic
 ## Author: MuffinManKen, Toadkiller (Original code)
-## Version: 1.15.7.02
+## Version: 1.15.9
 ## Notes: Dynamic bars with buttons that automatically add potions, water, food and other items you specify into a button for use. Does not use action slots.
 ## Notes-ruRU: Динамические панели с кнопками, которые автоматически добавляют зелья, воду, пищу и другие предметы для котрых вы определяете кнопки для использования. Не использует слоты на панеле команд.
 ## Notes-koKR: 자동으로 물약, 음료, 음식등이 포함된 버튼을 제공하며 슬롯에 사용할 아이템을 별도로 추가할 수 있습니다. 이것은 액션 슬롯에 여유를 가져다 줄것입니다.

--- a/AutoBarGlobals.lua
+++ b/AutoBarGlobals.lua
@@ -425,11 +425,7 @@ function code.add_profile_data(p_name, p_time)
 end
 
 function code.RegisterForClicks(p_frame)
-	if (AutoBarGlobalDataObject.is_vanilla_wow) then
-		p_frame:RegisterForClicks("AnyUp")
-	else
-		p_frame:RegisterForClicks("AnyUp", "AnyDown")
-	end
+	p_frame:RegisterForClicks("AnyUp", "AnyDown")
 end
 
 


### PR DESCRIPTION
I simply removed the special handling for vanilla warcraft now that it uses the same UI code base. Version number in TOC has been updated to reflect the patch from 7/22/2026